### PR TITLE
Convert use of flutter_session to flutter_secure_storage

### DIFF
--- a/lib/providers/user_auth/authenticate.dart
+++ b/lib/providers/user_auth/authenticate.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:flutter_session/flutter_session.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import '../../helpers/http_request.dart';
 
 class Authenticate with ChangeNotifier {
   var _authToken;
+  final storage = FlutterSecureStorage();
 
   Authenticate() {
     initAuthToken();
@@ -17,21 +18,22 @@ class Authenticate with ChangeNotifier {
   }
 
   void initAuthToken() async {
-    await FlutterSession()
-        .get('authentication_token')
+    await storage
+        .read(key: 'authentication_token')
         .then((value) => this.authToken = value)
-        .catchError((error) => print(error));
+        .catchError((error) {print(error);});
   }
 
   Future saveAuthToken(String authToken) async {
     this.authToken = authToken;
-    await FlutterSession().set('authentication_token', authToken);
+    await storage.write(key: 'authentication_token', value: authToken);
   }
 
   Future destroyAuthToken() async {
     this.authToken = null;
-    await FlutterSession().set('authentication_token', '');
+    await storage.delete(key: 'authentication_token');
   }
+
   /* 유저 로그인/회원가입 서버 개발 전 임시방편 코드
   Future signIn({Map<String, dynamic> params}) async {
     await HttpRequest()

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -85,20 +85,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
-  ffi:
-    dependency: transitive
-    description:
-      name: ffi
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.2"
-  file:
-    dependency: transitive
-    description:
-      name: file
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "6.1.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -123,13 +109,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
-  flutter_session:
+  flutter_secure_storage:
     dependency: "direct main"
     description:
-      name: flutter_session
+      name: flutter_secure_storage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1"
+    version: "5.0.2"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.2"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -252,27 +273,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.1"
-  path_provider_linux:
-    dependency: transitive
-    description:
-      name: path_provider_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.1+2"
-  path_provider_platform_interface:
-    dependency: transitive
-    description:
-      name: path_provider_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.4"
-  path_provider_windows:
-    dependency: transitive
-    description:
-      name: path_provider_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.5"
   pedantic:
     dependency: transitive
     description:
@@ -287,27 +287,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.1.0"
-  platform:
-    dependency: transitive
-    description:
-      name: platform
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.2.3"
+    version: "2.1.2"
   provider:
     dependency: "direct main"
     description:
@@ -315,48 +301,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.0.0"
-  shared_preferences:
-    dependency: transitive
-    description:
-      name: shared_preferences
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.12+4"
-  shared_preferences_linux:
-    dependency: transitive
-    description:
-      name: shared_preferences_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.2+4"
-  shared_preferences_macos:
-    dependency: transitive
-    description:
-      name: shared_preferences_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.1+11"
-  shared_preferences_platform_interface:
-    dependency: transitive
-    description:
-      name: shared_preferences_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.4"
-  shared_preferences_web:
-    dependency: transitive
-    description:
-      name: shared_preferences_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.2+7"
-  shared_preferences_windows:
-    dependency: transitive
-    description:
-      name: shared_preferences_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.2+3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -467,20 +411,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  win32:
-    dependency: transitive
-    description:
-      name: win32
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.3.1"
-  xdg_directories:
-    dependency: transitive
-    description:
-      name: xdg_directories
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.2"
   xml:
     dependency: transitive
     description:
@@ -489,5 +419,5 @@ packages:
     source: hosted
     version: "5.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"
   flutter: ">=2.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_session: ^0.1.1
   http: ^0.13.1
   provider: ^5.0.0
   cupertino_icons: ^1.0.2
@@ -35,6 +34,7 @@ dependencies:
   bot_toast: ^4.0.1
   dotted_border: ^2.0.0+1
   url_launcher: ^6.0.5
+  flutter_secure_storage: ^5.0.2
 
   # Image
   flutter_svg: ^0.23.0+1


### PR DESCRIPTION
This is a hotfix. 
Using flutter secure storage instead is to prevent pkg conflict w/ kakao sdk. This has a history from previous dev experience in guam 1.
Not using shared_preferences is since it saves key-value w/o securing. 

Please rebase existing branches according to this commit. 